### PR TITLE
Port COS build to cygwin/win7

### DIFF
--- a/CosBase/Makefile
+++ b/CosBase/Makefile
@@ -75,9 +75,9 @@ include $(cos)/epilogue
 .PHONY: bootstrap
 
 bootstrap: $(OSNAME)/bin/coscmt$(BINEXT)
-	$_ cp -fP bin/cosgen$(BINEXT) $(dir $<)
-	$_ cp -fP bin/cosprp$(BINEXT) $(dir $<)
-	$_ cp -fP bin/cossym$(BINEXT) $(dir $<)
+	$_ cp -fP bin/cosgen $(dir $<)
+	$_ cp -fP bin/cosprp $(dir $<)
+	$_ cp -fP bin/cossym $(dir $<)
 
 $(OSNAME)/bin/coscmt$(BINEXT): CCFLAGS := $(CCFLAGS)
 $(OSNAME)/bin/coscmt$(BINEXT): tools/src/coscmt.c

--- a/CosBase/include/cos/cfg/CYGWIN_NT-6.1
+++ b/CosBase/include/cos/cfg/CYGWIN_NT-6.1
@@ -1,0 +1,80 @@
+#
+#  C Object System
+#  COS makefile -- Default
+# 
+#  Copyright 2007+ Laurent Deniau <laurent.deniau@gmail.com>
+# 
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+#
+# install paths
+#
+PREFIX      := /usr
+BINDIR      := bin
+LIBDIR      := lib
+INCDIR      := include
+DOCDIR      := share/doc
+
+#
+# library specific
+#
+LIBTYPE     := static
+LIBPREFIX   := lib
+LIBAREXT    := .a
+
+#
+# program specific
+#
+BINTYPE     := static
+BINEXT      := .exe
+
+#
+# tools specific
+#
+CC          := gcc
+CPP         := $(CC) -E
+DEP         := $(CC) -M
+LD          := $(CC)
+AR          := ar -cr
+NM          := nm -P -g
+STRIP       := strip -s
+
+#
+# compiler and linker specific
+#
+CPPFLAGS    := -std=c99 -W -Wno-unused-local-typedefs -Wall -pedantic
+CCFLAGS     := -std=c99 -W -Wno-unused-local-typedefs -Wall -pedantic -O3
+LDFLAGS     := -std=c99 -W -Wno-unused-local-typedefs -Wall -pedantic -O3
+
+DEBUG_CPP   :=
+DEBUG_CC    := -g
+DEBUG_LD    := -g
+
+PROFILE_CPP :=
+PROFILE_CC  := -pg
+PROFILE_LD  := -pg
+
+RELEASE_CPP :=
+RELEASE_CC  := 
+RELEASE_LD  := 
+
+#
+# system specific
+#
+SYSFLAGS    := -DOSNAME=$(OSNAME) \
+               -D_XOPEN_SOURCE=500 -D_REENTRANT -D_THREAD_SAFE \
+               -D_FILE_OFFSET_BITS=64 -D_LARGEFILE64_SOURCE
+SYSLIBS     :=
+
+# end of makefile

--- a/CosBase/include/cos/cfg/CYGWIN_NT-6.1.h
+++ b/CosBase/include/cos/cfg/CYGWIN_NT-6.1.h
@@ -1,0 +1,31 @@
+#ifndef COS_CFG_CYGWIN_H
+#define COS_CFG_CYGWIN_H
+
+/**
+ * C Object System
+ * COS config: Cygwin
+ *
+ * Copyright 2006+ Laurent Deniau <laurent.deniau@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define COS_HAS_TLS   0
+#define COS_HAS_POSIX 1
+#define COS_HAS_DLINK 0  /* Debug static build first */
+
+#define COS_LIB_PREFIX "lib"
+#define COS_LIB_SHEXT  ".dll"
+
+#endif // COS_CFG_CYGWIN_H
+

--- a/CosBase/include/cos/mak/default
+++ b/CosBase/include/cos/mak/default
@@ -91,9 +91,9 @@ INSEXCMD := $(call rest,$(addprefix -o -name ,$(INSEXPAT) $(insexpat)))
 # standard tools
 #
 COSBIN   := $(call mkpath,$(wildcard $(COSDIR)/../../$(OSNAME)/bin))
-COSSYM    = $(if $(COSBIN),$(COSBIN)/)cossym$(BINEXT)
-COSGEN    = $(if $(COSBIN),$(COSBIN)/)cosgen$(BINEXT)
-COSPRP    = $(if $(COSBIN),$(COSBIN)/)cosprp$(BINEXT)
+COSSYM    = $(if $(COSBIN),$(COSBIN)/)cossym
+COSGEN    = $(if $(COSBIN),$(COSBIN)/)cosgen
+COSPRP    = $(if $(COSBIN),$(COSBIN)/)cosprp
 COSCMT    = $(if $(COSBIN),$(COSBIN)/)coscmt$(BINEXT)
 
 #


### PR DESCRIPTION
It now builds out of the box for the latest cygwin with
its gcc 5.3.0.  There was a minor change needed to the
non-cygwin specifc parts for the BINEXT usage.  It was
being used for both executables and sh script files.  I
believe it should only be applied to executables.

I would appreciate this being merged in the the COS upstream
but I'm not sure what development model you prefer to use.
From an email exchange, I understand you are not active
with COS for some time.  For me, I am interesteding in using
COS + JIT compiling (with tcc) for a next generation computational
kernel for the Perl Data Language (http://pdl.perl.org).

Please let me know how I can contribute my work.  I can
maintain a completely separate fork but that can be more
confusing than helpful.