### PR TITLE
Reorder moddeps to put StdBase after StdLib

### DIFF
--- a/CosStd/examples/ex01/Makefile
+++ b/CosStd/examples/ex01/Makefile
@@ -36,7 +36,7 @@ defgens :=
 defprps :=
 
 # project dependencies (as with -lname)
-moddeps := CosBase CosStd
+moddeps := CosStd CosBase
 
 # project dependencies (as with -Ipath or -Lpath)
 incdirs := ../../../CosBase/include ../../include .

--- a/CosStd/tests/Makefile
+++ b/CosStd/tests/Makefile
@@ -37,7 +37,7 @@ defgens := $(headers)
 defprps := $(headers)
 
 # project dependencies (as with -lname)
-moddeps := CosBase CosStd
+moddeps := CosStd CosBase
 
 # project dependencies (as with -Ipath or -Lpath)
 incdirs := $(foreach m,$(moddeps),../../$(m)/include) src


### PR DESCRIPTION
Originally command line linkers searched for symbols in the order
of the libraries and files on the command line.  That means that
since StdLib depends on StdBase you need to link a module using
StdLib _first_ agains -lStdLib (or whatever) and then -lStdBase
(or whatever).
