### PR TITLE
Remove useclass() of some unused classes

### DIFF
--- a/CosStd/src/File.c
+++ b/CosStd/src/File.c
@@ -42,7 +42,7 @@ makclass(OutputInputFile, OutputFile);
 // -----
 
 useclass(InputFile, OutputFile, InputOutputFile, OutputInputFile);
-useclass(ExBadStream, ExBadAlloc, AutoRelease, Array, String);
+useclass(ExBadStream, String);
 
 // -----
 

--- a/CosStd/src/String.c
+++ b/CosStd/src/String.c
@@ -37,7 +37,7 @@ makclass(StringN, String);
 
 // -----
 
-useclass(String, ExBadAlloc, ExOverflow);
+useclass(String, ExOverflow);
 
 // --- getters
 

--- a/CosStd/src/String_alg.c
+++ b/CosStd/src/String_alg.c
@@ -33,7 +33,7 @@
 
 // -----
 
-useclass(String, View, Array, ExBadAlloc);
+useclass(String, View, Array);
 useclass(Lesser,Equal,Greater);
 
 // ----- equality


### PR DESCRIPTION
Unless I misunderstand something these classes really are unused in these files.  This is detected by the (impicit) -Wunused-const-variable option which was added to gcc after the original COS development.
I'm aiming to get COS to compile without warnings.  I would appreciate any feedback on my planned next steps:

1. Make defmethod() emit a COS_UNUSED(ClassName) for bound classes.  I think this is needed because 
useclass emits const OBJ ClassName that is not directly mentioned by defmethod().  
-Wunused-const-variable is a useful warning that is worth preserving

2. Get rid of the many many -Wunused-local-typedefs either by passing -Wno-unused-local-typedefs, possibly depending on compiler support I guess.  Could either: always pass (maybe give up pre-2011 gcc compilers work right out of the box), or add compile type build system gcc version detection and pass conditionally, or use #pragma instead for easy gcc version detection.  Preference?