### PR TITLE
Remove useclass() of classes getting defmethod()

### DIFF
--- a/CosBase/include/cos/cfg/FreeBSD
+++ b/CosBase/include/cos/cfg/FreeBSD
@@ -100,7 +100,8 @@ SYSLIBS     := pthread dl
 CCFLAGS     += -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations \
                -Wchar-subscripts -Wformat-nonliteral -Wwrite-strings \
                -Wpointer-arith -Wbad-function-cast -Wcast-align -Wcast-qual \
-               -Wfloat-equal -Wconversion -Wno-conversion -Winline
+               -Wfloat-equal -Wconversion -Wno-conversion -Winline \
+               -Wno-unused-local-typedefs
 
 # CCFLAGS   += --param large-function-growth=400 --param inline-unit-growth=200
 

--- a/CosBase/include/cos/cfg/Linux
+++ b/CosBase/include/cos/cfg/Linux
@@ -100,7 +100,8 @@ SYSLIBS     := pthread dl
 CCFLAGS     += -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations \
                -Wchar-subscripts -Wformat-nonliteral -Wwrite-strings \
                -Wpointer-arith -Wbad-function-cast -Wcast-align -Wcast-qual \
-               -Wfloat-equal -Wconversion -Wno-conversion -Winline
+               -Wfloat-equal -Wconversion -Wno-conversion -Winline \
+               -Wno-unused-local-typedefs
 
 # CCFLAGS   += --param large-function-growth=400 --param inline-unit-growth=200
 

--- a/CosBase/include/cos/cfg/SunOS
+++ b/CosBase/include/cos/cfg/SunOS
@@ -100,7 +100,8 @@ SYSLIBS     := pthread dl
 CCFLAGS     += -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations \
                -Wchar-subscripts -Wformat-nonliteral -Wwrite-strings \
                -Wpointer-arith -Wbad-function-cast -Wcast-align -Wcast-qual \
-               -Wfloat-equal -Wconversion -Wno-conversion -Winline
+               -Wfloat-equal -Wconversion -Wno-conversion -Winline \
+               -Wno-unused-local-typedefs
 
 # CCFLAGS   += --param large-function-growth=400 --param inline-unit-growth=200
 

--- a/CosBase/src/cos_symbol.c
+++ b/CosBase/src/cos_symbol.c
@@ -670,6 +670,7 @@ sym_init(void)
       case cos_tag_pclass : ++n_pcl; pcl_stinit((void*)tbl_sym[t][s]); break;
       case cos_tag_generic: ++n_gen; gen_stinit((void*)tbl_sym[t][s]); break;
       case cos_tag_alias  :          als_stinit((void*)tbl_sym[t][s]);
+      /* intentional fall through */
       case cos_tag_method : ++n_mth; break;
       case cos_tag_docstr : ++n_doc; break;
       default: cos_abort("invalid COS symbol");
@@ -702,12 +703,15 @@ sym_init(void)
         if (sym.bhv[i]) {
           switch (bhv->Object.Any._rc) {
           case cos_tag_class :
+          /* intentional fall through */
           case cos_tag_pclass:
+          /* intentional fall through */
           case cos_tag_mclass: {
             struct Class *cls = CAST(struct Class*, bhv);
             cos_abort("class '%s' at (%s,%d) slot %u already assigned",
                       cls_name(cls), cls_file(cls), cls_line(cls), i);
           }
+          /* intentional fall through */
           case cos_tag_generic: {
             struct Generic *gen = CAST(struct Generic*, bhv);
             cos_abort("generic '%s' at (%s,%d) slot %u already assigned",

--- a/CosBase/tools/src/coscmt.c
+++ b/CosBase/tools/src/coscmt.c
@@ -95,6 +95,7 @@ remove_cmt(FILE *in , FILE *out)
                  if (c == '/') { skip_line(in); break; }
                  if (c == '*') { skip_cmt (in); break; }
                  fputc('/', out);
+      /* intentional fall through */
       default  : fputc(c  , out);
     }
   }

--- a/CosStd/src/File.c
+++ b/CosStd/src/File.c
@@ -41,8 +41,8 @@ makclass(OutputInputFile, OutputFile);
 
 // -----
 
-useclass(InputFile, OutputFile, InputOutputFile, OutputInputFile);
-useclass(ExBadStream, String);
+useclass(InputFile, OutputFile);
+useclass(ExBadStream);
 
 // -----
 

--- a/CosStd/src/String_alg.c
+++ b/CosStd/src/String_alg.c
@@ -33,7 +33,7 @@
 
 // -----
 
-useclass(String, View, Array);
+useclass(View, Array);
 useclass(Lesser,Equal,Greater);
 
 // ----- equality

--- a/CosStd/src/String_dyn.c
+++ b/CosStd/src/String_dyn.c
@@ -36,7 +36,7 @@ makclass(StringDyn, StringFix);
 
 // -----
 
-useclass(String, StringDyn, ExBadAlloc, ExOverflow);
+useclass(StringDyn, ExBadAlloc, ExOverflow);
 
 // ----- getter
 

--- a/INSTALL
+++ b/INSTALL
@@ -48,11 +48,12 @@ Tested platforms:
 # System & Architectures
 Linux Ubuntu 8.04, 8.10, 9.04, 9.10 (Debian) on i386   (32-bit) Core2 Duo
 Linux Ubuntu 8.04, 8.10, 9.04, 9.10 (Debian) on x86_64 (64-bit) Core2 Duo
+Linux Debian 8.11 on x86_64 (64-bit) Intel 8-core Xeon
 Linux SLC 4.0, 5.0 (RedHat) on x86_64 (64-bit) Quad Xeon
 Mac OS X Leopard (Darwin) on x86_64 (64-bit) Core2 Duo
 
 # Compilers
-gcc 3.2.3, 3.4.6, 4.1.2, 4.2.4, 4.3.2, 4.3.3
+gcc 3.2.3, 3.4.6, 4.1.2, 4.2.4, 4.3.2, 4.3.3, 7.2.0
 
 Other available platforms (untested):
 -------------------------------------

--- a/README
+++ b/README
@@ -132,7 +132,7 @@ Mac OSX from Leopard to El Capitan on x86_64 multicore
 Windows from 7 to 10 on x86_64 multicore using MSys2 (mingw64)
 
 # Compilers
-gcc from 3.2.3 to 4.8.5
+gcc from 3.2.3 to 4.8.5 and 7.2.0
 
 Other available platforms (untested):
 -------------------------------------


### PR DESCRIPTION
Remove some more useclass()ed classes that trigger -Wunused-const-variable.

These are a little weirder because the classes in question are used to specialize generics (i.e. class names are passed to defmethod()) but I think this is still the correct approach.  CosStd does it this way elsewhere already.  In this view useclass() is for classes that are messaged or used as first-class objects, while defmethod() is part of the class definition (shared with other classes for specializations with rank >1 and >1 receiver type).