### PR TITLE
cos_functor_clearContext() in cos_deinit()

### DIFF
--- a/CosBase/src/cos_symbol.c
+++ b/CosBase/src/cos_symbol.c
@@ -907,6 +907,7 @@ cos_deinit(void)
     t1 = clock();
     deinit_duration = (t1-t0)/CLOCKS_PER_SEC;
 
+    cos_functor_clearContext();
     cos_method_clearCaches();
   }
 }


### PR DESCRIPTION
This keeps COS clean with respect to e.g. valgrind when functors are used.  COS is already very clean in this way and I think it's worth the tiny additional shutdown time to keep it that way.  All tests pass and I think there is no interaction with cos_method_clearCaches(), but I'm not sure if there is some order you might prefer with respect to that function.