### PR TITLE
Prevent function type cast warnings on gcc-8

### DIFF
--- a/CosBase/include/cos/cos/method.h
+++ b/CosBase/include/cos/cos/method.h
@@ -369,7 +369,7 @@ static void COS_MTH_MNAME(COS_FCT_NAME(NAME,CS),TAG,T) \
   /* indirect invocation, normal */ \
    _cos_mth_nxt_g(__VA_ARGS__,_cos_mth_nxt_sel,_ret,_cos_mth_nxt_p) : \
   /* direct invocation, if GUM */ \
-   ((_cos_mth_nxt_d)_cos_mth_nxt_p)(_sel,__VA_ARGS__,_arg,_ret)))
+   ((_cos_mth_nxt_d)(void (*)(void))_cos_mth_nxt_p)(_sel,__VA_ARGS__,_arg,_ret)))
 
 #define COS_MTH_NXT_P \
   /* next_method check */ \

--- a/README
+++ b/README
@@ -132,7 +132,7 @@ Mac OSX from Leopard to El Capitan on x86_64 multicore
 Windows from 7 to 10 on x86_64 multicore using MSys2 (mingw64)
 
 # Compilers
-gcc from 3.2.3 to 4.8.5 and 7.2.0
+gcc from 3.2.3 to 4.8.5, 7.2.0, and 8.2.0
 
 Other available platforms (untested):
 -------------------------------------


### PR DESCRIPTION
I think these casts are correct in the sense that they cast the pointer back to it's original type, so it's reasonable to suppress this warning.  I'm not sure of this however, as I don't completely understand how COS methods are implemented.

This question can be relevant as there is now at least one C environment (emscripten) in which some function pointer casts that have historically worked on all existing machines cause failures.