### PR TITLE
Fix implicit conversion to unsigned bugs...

### DIFF
--- a/CosStd/include/cos/Range.h
+++ b/CosStd/include/cos/Range.h
@@ -88,7 +88,8 @@ endclass
 */
 static cos_inline U32
 Range_index(I32 index, U32 seq_size) {
-  return index + (index < 0) * seq_size;
+  // OK because signed=>unsigned cast and unsigned overflow are well defined:
+  return (U32)index + (index < 0) * seq_size;
 }
 
 /***********************************************************

--- a/CosStd/src/Array.c
+++ b/CosStd/src/Array.c
@@ -283,7 +283,7 @@ defmethod(OBJ,  ginitWith2          , pmArray, Array, IntVector) // random seque
   while (dst != end) {
     U32 i = Range_index(*idx, val_n);
     ensure( i < val_n, "index out of range" );
-    *dst++ = gretain(val[i*val_s]), ++*dst_n;
+    *dst++ = gretain(val[(ptrdiff_t)i*val_s]), ++*dst_n;
     idx += idx_s;
   }
 
@@ -339,7 +339,7 @@ defmethod(void, ginvariant, Array, (STR)file, (int)line)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
 
   while (val != end && *val)
     val += val_s;

--- a/CosStd/src/Array_acc.c
+++ b/CosStd/src/Array_acc.c
@@ -49,10 +49,10 @@ endmethod
 
 defmethod(OBJ, ggetAtIdx, Array, (I32)idx)
   U32 i = Range_index(idx, self->size);
-  
+
   ensure( i < self->size, "index out of range" );
 
-  retmethod( self->object[i*self->stride] );
+  retmethod( self->object[(ptrdiff_t)i*self->stride] );
 endmethod
 
 defmethod(OBJ, ggetAt, Array, Int)
@@ -60,7 +60,7 @@ defmethod(OBJ, ggetAt, Array, Int)
 
   ensure( i < self->size, "index out of range" );
 
-  retmethod( self->object[i*self->stride] );
+  retmethod( self->object[(ptrdiff_t)i*self->stride] );
 endmethod
 
 defmethod(OBJ, ggetAt, Array, Slice)
@@ -87,7 +87,7 @@ defmethod(OBJ, gputAtIdx, Array, (I32)idx, Object)
   
   ensure( i < self->size, "index out of range" );
 
-  OBJ *dst = self->object + i*self->stride;
+  OBJ *dst = self->object + (ptrdiff_t)i*self->stride;
   assign(dst, _2);
     
   retmethod(_1);
@@ -98,7 +98,7 @@ defmethod(OBJ, gputAt, Array, Int, Object)
   
   ensure( i < self->size, "index out of range" );
 
-  OBJ *dst = self->object + i*self->stride;
+  OBJ *dst = self->object + (ptrdiff_t)i*self->stride;
   assign(dst, _3);
     
   retmethod(_1);
@@ -112,7 +112,7 @@ BODY
   U32  dst_n = Slice_size  (self2);
   I32  dst_s = Slice_stride(self2)*self->stride;
   OBJ *dst   = Slice_start (self2)*self->stride + self->object;
-  OBJ *end   = dst + dst_s*dst_n;
+  OBJ *end   = dst + dst_s*(ptrdiff_t)dst_n;
 
   while (dst != end) {
     assign(dst, _3);
@@ -136,7 +136,7 @@ defmethod(OBJ, gputAt, Array, IntVector, Object)
   U32  idx_n = self2->size;
   I32  idx_s = self2->stride;
   I32 *idx   = self2->value;
-  I32 *end   = idx + idx_s*idx_n;
+  I32 *end   = idx + idx_s*(ptrdiff_t)idx_n;
 
   while (idx != end) {
     U32 i = Range_index(*idx, dst_n);
@@ -168,7 +168,7 @@ BODY
   OBJ *dst   = Slice_start (self2)*self->stride + self->object;
   I32  src_s = self3->stride;
   OBJ *src   = self3->object;
-  OBJ *end   = dst + dst_s*dst_n;
+  OBJ *end   = dst + dst_s*(ptrdiff_t)dst_n;
 
   while (dst != end) {
     assign(dst, *src);
@@ -199,7 +199,7 @@ BODY
   I32 *idx   = self2->value;
   I32  src_s = self3->stride;
   OBJ *src   = self3->object;
-  I32 *end   = idx + idx_s*idx_n;
+  I32 *end   = idx + idx_s*(ptrdiff_t)idx_n;
 
   while (idx != end) {
     U32 i = Range_index(*idx, dst_n);

--- a/CosStd/src/Array_acc.c
+++ b/CosStd/src/Array_acc.c
@@ -141,7 +141,7 @@ defmethod(OBJ, gputAt, Array, IntVector, Object)
   while (idx != end) {
     U32 i = Range_index(*idx, dst_n);
     ensure( i < dst_n, "index out of range" );
-    assign(dst + i*dst_s, _3);
+    assign(dst + (ptrdiff_t)i*dst_s, _3);
     idx += idx_s;
   }
   
@@ -204,7 +204,7 @@ BODY
   while (idx != end) {
     U32 i = Range_index(*idx, dst_n);
     ensure( i < dst_n, "index out of range" );
-    assign(dst + i*dst_s, *src);
+    assign(dst + (ptrdiff_t)i*dst_s, *src);
     src += src_s;
     idx += idx_s;
   }

--- a/CosStd/src/Array_alg.c
+++ b/CosStd/src/Array_alg.c
@@ -54,7 +54,7 @@ defmethod(OBJ, gisEqual, Array, Array)
   OBJ *val    = self->object;
   I32  val2_s = self2->stride;
   OBJ *val2   = self2->object;
-  OBJ *end    = val + val_s*val_n;
+  OBJ *end    = val + val_s*(ptrdiff_t)val_n;
   
   while (val != end) {
     if (gisEqual(*val,*val2) != True)
@@ -80,7 +80,7 @@ defmethod(OBJ, gcompare, Array, Array)
   OBJ *val    = self->object;
   I32  val2_s = self2->stride;
   OBJ *val2   = self2->object;
-  OBJ *end    = val + val_s*val_n;
+  OBJ *end    = val + val_s*(ptrdiff_t)val_n;
   OBJ  res;
 
   while (val != end) {
@@ -111,7 +111,7 @@ defmethod(OBJ, greverse, Array)
   U32  val_n = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*(val_n-1);
+  OBJ *end   = val + val_s*(ptrdiff_t)(val_n-1);
 
   if (val_s > 0)
     while (val < end) {
@@ -155,7 +155,7 @@ defmethod(OBJ, gpermute, Array, IntVector)
     for (cur = buf; cur != end; cur++) {
       i = Range_index(*idx, size);
       if ( !(i < size && flg[i]) ) break;
-      *cur = val[i*val_s], flg[i] = 0;
+      *cur = val[(ptrdiff_t)i*val_s], flg[i] = 0;
        idx += idx_s;
     }
 
@@ -173,7 +173,7 @@ defmethod(OBJ, gpermute, Array, IntVector)
       while (cur != buf) {
         idx -= idx_s;
         i = Range_index(*idx, size);
-        val[i*val_s] = *--cur;
+        val[(ptrdiff_t)i*val_s] = *--cur;
       }
 
       CARRAY_DESTROY(buf);
@@ -450,7 +450,7 @@ findVal(OBJ *val, U32 val_n, I32 val_s, OBJ _2)
 {
   if (!val_n) return 0;
 
-  OBJ *end = val + val_s*val_n;
+  OBJ *end = val + val_s*(ptrdiff_t)val_n;
 
   while (val != end) {
     if (gisEqual(_2, *val) == True)

--- a/CosStd/src/Array_fun.c
+++ b/CosStd/src/Array_fun.c
@@ -40,7 +40,7 @@ defmethod(void, gforeachWhile, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
 
   while (val != end && geval(_2, *val) != Nil)
     val += val_s;
@@ -50,7 +50,7 @@ defmethod(void, gforeach, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
 
   while (val != end) {
     geval(_2, *val);
@@ -64,7 +64,7 @@ defmethod(void, gforeach2, Array, Array, Functor)
   OBJ *val    = self->object;
   I32  val2_s = self2->stride;
   OBJ *val2   = self2->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
 
   while (val != end) {
     geval(_3, *val, *val2);
@@ -82,7 +82,7 @@ defmethod(void, gforeach3, Array, Array, Array, Functor)
   OBJ *val2   = self2->object;
   I32  val3_s = self3->stride;
   OBJ *val3   = self3->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
 
   while (val != end) {
     geval(_4, *val, *val2, *val3);
@@ -104,7 +104,7 @@ defmethod(void, gforeach4, Array, Array, Array, Array, Functor)
   OBJ *val3   = self3->object;
   I32  val4_s = self4->stride;
   OBJ *val4   = self4->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
 
   while (val != end) {
     geval(_5, *val, *val2, *val3, *val4);
@@ -121,7 +121,7 @@ defmethod(OBJ, gapplyWhile, Functor, Array)
   U32  size  = self2->size;
   I32  val_s = self2->stride;
   OBJ *val   = self2->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res, old;
 
   while (val != end) {
@@ -139,7 +139,7 @@ defmethod(OBJ, gapplyIf, Functor, Array)
   U32  size  = self2->size;
   I32  val_s = self2->stride;
   OBJ *val   = self2->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res, old;
 
   while (val != end) {
@@ -156,7 +156,7 @@ defmethod(OBJ, gapply, Functor, Array)
   U32  size  = self2->size;
   I32  val_s = self2->stride;
   OBJ *val   = self2->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res, old;
 
   while (val != end) {
@@ -175,7 +175,7 @@ defmethod(OBJ, gapply2, Functor, Array, Array)
   OBJ *val    = self2->object;
   I32  val2_s = self3->stride;
   OBJ *val2   = self3->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
   OBJ  res, old;
 
   while (val != end) {
@@ -198,7 +198,7 @@ defmethod(OBJ, gapply3, Functor, Array, Array, Array)
   OBJ *val2   = self3->object;
   I32  val3_s = self4->stride;
   OBJ *val3   = self4->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
   OBJ  res, old;
 
   while (val != end) {
@@ -225,7 +225,7 @@ defmethod(OBJ, gapply4, Functor, Array, Array, Array, Array)
   OBJ *val3   = self4->object;
   I32  val4_s = self5->stride;
   OBJ *val4   = self5->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
   OBJ  res, old;
 
   while (val != end) {
@@ -247,7 +247,7 @@ defmethod(OBJ, gmapWhile, Functor, Array)
   U32  size  = self2->size;
   I32  val_s = self2->stride;
   OBJ *val   = self2->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res;
 
   OBJ _arr = gautoRelease(gnewWith(Array,aInt(size)));
@@ -270,7 +270,7 @@ defmethod(OBJ, gmapIf, Functor, Array)
   U32  size  = self2->size;
   I32  val_s = self2->stride;
   OBJ *val   = self2->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res;
 
   OBJ _arr = gautoRelease(gnewWith(Array,aInt(size)));
@@ -293,7 +293,7 @@ defmethod(OBJ, gmap, Functor, Array)
   U32  size  = self2->size;
   I32  val_s = self2->stride;
   OBJ *val   = self2->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res;
 
   struct Array* arr = Array_alloc(size);
@@ -317,7 +317,7 @@ defmethod(OBJ, gmap2, Functor, Array, Array)
   OBJ *val    = self2->object;
   I32  val2_s = self3->stride;
   OBJ *val2   = self3->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
   OBJ  res;
 
   struct Array* arr = Array_alloc(size);
@@ -345,7 +345,7 @@ defmethod(OBJ, gmap3, Functor, Array, Array, Array)
   OBJ *val2   = self3->object;
   I32  val3_s = self4->stride;
   OBJ *val3   = self4->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
   OBJ  res;
 
   struct Array* arr = Array_alloc(size);
@@ -377,7 +377,7 @@ defmethod(OBJ, gmap4, Functor, Array, Array, Array, Array)
   OBJ *val3   = self4->object;
   I32  val4_s = self5->stride;
   OBJ *val4   = self5->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
   OBJ  res;
 
   struct Array* arr = Array_alloc(size);
@@ -404,7 +404,7 @@ defmethod(OBJ, gselect, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
 
   OBJ _arr = gautoRelease(gnewWith(Array,aInt(size)));
   struct Array* arr = dbgcast(Array, _arr);
@@ -425,7 +425,7 @@ defmethod(OBJ, greject, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
 
   OBJ _arr = gautoRelease(gnewWith(Array,aInt(size)));
   struct Array* arr = dbgcast(Array, _arr);
@@ -446,7 +446,7 @@ defmethod(OBJ, gselectWhile, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   
   OBJ _arr = gautoRelease(gnewWith(Array,aInt(size)));
   struct Array* arr = dbgcast(Array, _arr);
@@ -468,7 +468,7 @@ defmethod(OBJ, grejectWhile, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
 
   OBJ _arr = gautoRelease(gnewWith(Array,aInt(size)));
   struct Array* arr = dbgcast(Array, _arr);
@@ -505,7 +505,7 @@ defmethod(OBJ, greduce, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = gautoRelease(gclone(*val));
   
   val += val_s;
@@ -522,7 +522,7 @@ defmethod(OBJ, greduce1, Array, Functor, Object)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = _3;
   
   while (val != end) {
@@ -546,7 +546,7 @@ defmethod(OBJ, greduce2, Array, Functor, Object, Object)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = _3;
 
   if (size) {
@@ -578,7 +578,7 @@ defmethod(OBJ, grreduce, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = gautoRelease(gclone(*(end-val_s)));
 
   end -= val_s;
@@ -595,7 +595,7 @@ defmethod(OBJ, grreduce1, Array, Functor, Object)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = _3;
   
   while (val != end) {
@@ -621,7 +621,7 @@ defmethod(OBJ, grreduce2, Array, Functor, Object, Object)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = _3;
 
   if (size) {
@@ -662,7 +662,7 @@ defmethod(OBJ, gaccumulate1, Array, Functor, Object)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = _3;
 
   struct Array* arr = Array_alloc(size);
@@ -693,7 +693,7 @@ defmethod(OBJ, gaccumulate2, Array, Functor, Object, Object)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = _3;
 
   struct Array* arr = Array_alloc(size);
@@ -740,7 +740,7 @@ defmethod(OBJ, graccumulate1, Array, Functor, Object)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = _3;
 
   struct Array* arr = Array_alloc(size);
@@ -772,7 +772,7 @@ defmethod(OBJ, graccumulate2, Array, Functor, Object, Object)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res   = _3;
 
   struct Array* arr = Array_alloc(size);
@@ -804,7 +804,7 @@ defmethod(OBJ, gall, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
 
   while (val != end) {
     if (geval(_2, *val) != True)
@@ -819,7 +819,7 @@ defmethod(OBJ, gany, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
 
   while (val != end) {
     if (geval(_2, *val) == True)
@@ -834,7 +834,7 @@ defmethod(U32, gcount, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   U32  cnt   = 0;
 
   while (val != end) {
@@ -857,7 +857,7 @@ defmethod(OBJ, gunique, Array, Functor)
   OBJ *val   = self->object;
   U32 *dst_n = &arr->size;
   OBJ *dst   = arr->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
 
   if (val != end) {
     *dst = gretain(*val), ++*dst_n;
@@ -881,7 +881,7 @@ defmethod(OBJ, gsplit, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ *beg   = val;
 
   while (val != end) {
@@ -917,7 +917,7 @@ defmethod(OBJ, ggroup, Array, Functor)
   U32  size  = self->size;
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*size;
+  OBJ *end   = val + val_s*(ptrdiff_t)size;
   OBJ  res;
 
   while (val != end) {
@@ -980,7 +980,7 @@ defmethod(OBJ, gdiff, Array, Collection, Functor)
   OBJ *val    = self->object;
   U32 *dst_n  = &arr->size;
   OBJ *dst    = arr->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
   OBJ  fun    = aFun(gfind, _2, aFun(geval2, _3, __2, __1));
 
   while (val != end) {
@@ -1003,7 +1003,7 @@ defmethod(OBJ, gmatch, Array, Collection, Functor)
   OBJ *val    = self->object;
   U32 *dst_n  = &arr->size;
   OBJ *dst    = arr->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
   OBJ  fun    = aLzy(_3);
   OBJ  res;
 
@@ -1029,7 +1029,7 @@ defmethod(OBJ, gintersect, Array, Collection, Functor)
   OBJ *val    = self->object;
   U32 *dst_n  = &arr->size;
   OBJ *dst    = arr->object;
-  OBJ *end    = val + val_s*size;
+  OBJ *end    = val + val_s*(ptrdiff_t)size;
   OBJ  fun    = aFun(gfind, _2, aFun(geval2, _3, __2, __1));
 
   while (val != end) {
@@ -1055,7 +1055,7 @@ findFun(OBJ *val, U32 val_n, I32 val_s, OBJ _2)
 
   // linear search
   if (res == False) {
-    OBJ *end = val + val_s*val_n;
+    OBJ *end = val + val_s*(ptrdiff_t)val_n;
 
     val += val_s;
     while (val != end) {
@@ -1073,10 +1073,10 @@ findFun(OBJ *val, U32 val_n, I32 val_s, OBJ _2)
 
     while (lo <= hi) {
       U32 i = (lo + hi) / 2;
-      res = geval(_2, val[i*val_s]);
+      res = geval(_2, val[(ptrdiff_t)i*val_s]);
 
       if (res == Equal)
-        return val + i*val_s; // found
+        return val + (ptrdiff_t)i*val_s; // found
 
       if (res == Lesser)
         hi = i-1;
@@ -1389,7 +1389,7 @@ defmethod(OBJ, gisSorted, Array, Functor)
 
   I32  val_s = self->stride;
   OBJ *val   = self->object;
-  OBJ *end   = val + val_s*(size-1);
+  OBJ *end   = val + val_s*(ptrdiff_t)(size-1);
   OBJ  res;
   
   while (val != end) {


### PR DESCRIPTION
This makes e.g. negatively strided views work as intended:

  OBJ ary = aArray(aInt(1), aInt(2), aInt(3));
  OBJ ary_view = aArrayView(ary, aRange(-1, 1, -1));
  for ( unsigned ii = 0 ; ii < gsize(ary_view); ii++ ) {
    printf ("  %u: %i\n", ii, gint(ggetAt(ary_view, aInt(ii))));

won't seg fault now.  As usual fully fixing this problem for all pointer
widths is excruciating and inefficient, so we don't.  Using ptrdiff_t
gives decent results on 32 bit and works for all realistic offsets on 64
bit.  It's tempting to use I64 rather than ptrdiff_t to make the
operation explicit, but that might not work right on 32 bit (I'm not
sure).

This probably isn't all the bugs of this sort.  At least the following
look suspicious:

src/Array_alg.c:547:35: warning: conversion from 'long int' to 'U32' {aka 'unsigned int'} may change value [-Wconversion]

src/./tmpl/Vector_alg.c:406:35: warning: conversion from 'long int' to 'U32' {aka 'unsigned int'} may change value [-Wconversion]

src/String_alg.c:308:35: warning: conversion from 'long int' to 'U32' {aka 'unsigned int'} may change value [-Wconversion]

The fixes for those look a little harder though, as the suspicious
intermediate results get sent off to an unsigned argument to
KnuthMorrisPratt() (which function would also likely need to be fixed).

The Range_index() function in Range.h seems to work right and it looks
like the mechanism is well-defined even if it is a little scary.  I
added an explicit cast and comment to make it clear what's going on.